### PR TITLE
fix(sweeps): do not ignore parameter distribution in sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Fix multipart uploads for files with no content type defined in headers (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8716)
 - Fixed tensorboard failing to sync when logging batches of images. (@jacobromero in https://github.com/wandb/wandb/pull/8641)
 - Fixed behavior of `mode='x'`/`mode='w'` in `Artifact.new_file()` to conform to Python's built-in file modes (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8553)
-- Do not ignore parameter `distribution` when configuring sweep parameters from SDK.
+- Do not ignore parameter `distribution` when configuring sweep parameters from SDK. (@temporaer in https://github.com/wandb/wandb/pull/8737)
 
 ### Changed
 - Added internal method, api._artifact(), to fetch artifacts so that usage events are not created if not called by an external user. (@ibindlish in https://github.com/wandb/wandb/pull/8674)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please add to the relevant subsections under Unreleased below on every PR where 
 - Fix multipart uploads for files with no content type defined in headers (@amusipatla-wandb in https://github.com/wandb/wandb/pull/8716)
 - Fixed tensorboard failing to sync when logging batches of images. (@jacobromero in https://github.com/wandb/wandb/pull/8641)
 - Fixed behavior of `mode='x'`/`mode='w'` in `Artifact.new_file()` to conform to Python's built-in file modes (@tonyyli-wandb in https://github.com/wandb/wandb/pull/8553)
+- Do not ignore parameter `distribution` when configuring sweep parameters from SDK.
 
 ### Changed
 - Added internal method, api._artifact(), to fetch artifacts so that usage events are not created if not called by an external user. (@ibindlish in https://github.com/wandb/wandb/pull/8674)

--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -307,6 +307,8 @@ class _WandbController:
             self._create["parameters"][name]["value"] = value
         if values is not None:
             self._create["parameters"][name]["values"] = values
+        if distribution is not None:
+            self._create["parameters"][name]["distribution"] = distribution
         if min is not None:
             self._create["parameters"][name]["min"] = min
         if max is not None:


### PR DESCRIPTION
Description
-----------

`sweep.configure_parameter()` silently ignored the `distribution` parameter. This PR saves it in the parameter dict.

- [ ] I updated CHANGELOG.md, or it's not applicable


Testing
-------
How was this PR tested?

